### PR TITLE
Add example to store credentials with a group + bug fix

### DIFF
--- a/addons/destinations/CreateGitDestination.ipynb
+++ b/addons/destinations/CreateGitDestination.ipynb
@@ -307,7 +307,7 @@
     "        \"value\": localRepositoryLocation},\n",
     "        {\"name\": \"userEmail\",\n",
     "        \"value\": userEmail},\n",
-    "        {\"name\": \"credDomainID\",\n",
+    "        {\"name\": \"domainID\",\n",
     "        \"value\": domain_name},\n",
     "        {\"name\": \"codeGenerationMode\",\n",
     "        \"value\": codeGenerationMode}]\n",

--- a/addons/destinations/CreateGitDestination.ipynb
+++ b/addons/destinations/CreateGitDestination.ipynb
@@ -39,7 +39,9 @@
     "import base64\n",
     "import urllib.parse\n",
     "\n",
-    "hostport=\"<host_name:port>\""
+    "requests.packages.urllib3.disable_warnings()\n",
+    "\n",
+    "hostport=\"https://viyatogo-singlenode\""
    ]
   },
   {
@@ -53,6 +55,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -90,6 +93,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -124,7 +128,7 @@
     "\n",
     "# The domain name can be any easy to remember name. For example: gitdomain\n",
     "domain_name = input(\"Enter a domain name: \")\n",
-    "domain_description = input(\"Enter a domain description: \")\n",
+    "domain_description = input(\"Enter a domain description (optional): \")\n",
     "\n",
     "my_domain_url = hostport + domains_uri + domain_name\n",
     "domain_attrs = {\n",
@@ -159,8 +163,10 @@
     "domains = requests.get(hostport + domains_uri_limit, headers=headersGet)\n",
     "\n",
     "print(domains)\n",
+    "\n",
     "for i, domain in enumerate(domains.json()[\"items\"]):\n",
     "    print(\"%3d. domain name : %s \" % (i, domain[\"id\"]))\n",
+    "\n",
     "itemNotSelected = True\n",
     "while itemNotSelected : \n",
     "    domainIndex = input(\"Enter the index number to select a domain: \")\n",
@@ -169,6 +175,7 @@
     "        itemNotSelected = False\n",
     "    except:\n",
     "        print(\"Please enter the index number for a domain to select it from the list.\")\n",
+    "\n",
     "print(domain_name)"
    ]
   },
@@ -205,13 +212,13 @@
     "}\n",
     "\n",
     "# User credential name is the user ID on a SAS Viya system.\n",
-    "user_credential_name = input(\"Enter the user credential name: \")\n",
+    "user_credential_name = input(\"Enter the SAS Viya user name: \")\n",
     "my_credential_url = hostport + domains_uri + domain_name + \"/users/\" + user_credential_name\n",
     "\n",
     "# User ID in Git\n",
     "gitUserId = input(\"Enter your Git user ID: \")\n",
     "\n",
-    "gitAccessToken = input(\"Enter the name of the Git access token: \")\n",
+    "gitAccessToken = input(\"Enter the value of the Git access token: \")\n",
     "\n",
     "encoded_userId = str(base64.b64encode(gitUserId.encode(\"utf-8\")), \"utf-8\")\n",
     "encoded_password = str(base64.b64encode(gitAccessToken.encode(\"utf-8\")), \"utf-8\")\n",
@@ -246,12 +253,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "credential_uri = \"/credentials/domains/\"+domain_name+\"/credentials\"\n",
+    "credential_uri = \"/credentials/domains/\" + domain_name + \"/credentials\"\n",
     "credentials = requests.get(hostport + credential_uri, headers=headersGet)\n",
     "\n",
     "print(credentials)\n",
     "for i, cred in enumerate(credentials.json()[\"items\"]):\n",
     "    print(\"%3d. credential name : %s \" % (i, cred[\"identityId\"]))\n",
+    "\n",
     "itemNotSelected = True\n",
     "while itemNotSelected : \n",
     "    credIndex = input(\"Enter the index number to select a credential: \")\n",
@@ -260,6 +268,7 @@
     "        itemNotSelected = False\n",
     "    except:\n",
     "        print(\"Please enter an index number to select a credential from the list.\")\n",
+    "\n",
     "print(cred_name)"
    ]
   },
@@ -276,6 +285,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -283,8 +293,11 @@
    "outputs": [],
    "source": [
     "destName = input(\"Enter a destination name: \")\n",
-    "destDescription = input('Enter a description for the destination %s: ' % destName)\n",
+    "destDescription = input('Enter a description for the destination %s (optional): ' % destName)\n",
     "userEmail = input(\"Enter your user email address for Git: \")\n",
+    "\n",
+    "# This should be the HTTPS Clone URL of your Git Repository\n",
+    "# e.g. https://github.com/sassoftware/model-management-resources.git\n",
     "remoteRepositoryURL = input(\"Enter the URL for the Git Repository: \")\n",
     "gitBranch = input(\"Enter the Git branch: \")\n",
     "\n",
@@ -307,11 +320,11 @@
     "        \"value\": localRepositoryLocation},\n",
     "        {\"name\": \"userEmail\",\n",
     "        \"value\": userEmail},\n",
-    "        {\"name\": \"domainID\",\n",
+    "        {\"name\": \"credDomainId\",\n",
     "        \"value\": domain_name},\n",
     "        {\"name\": \"codeGenerationMode\",\n",
     "        \"value\": codeGenerationMode}]\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -325,6 +338,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -338,6 +352,7 @@
     "\n",
     "destination = requests.post(hostport + \"/modelPublish/destinations\", \n",
     "                       data=json.dumps(targetDestination), headers=headersPost, verify=False)\n",
+    "\n",
     "print(destination)\n",
     "pprint.pprint(destination.json())"
    ]
@@ -353,6 +368,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -375,6 +391,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -389,11 +406,90 @@
     "deleteDestination = requests.delete(hostport + \"/modelPublish/destinations/\" + destName, headers = headersDelete)\n",
     "print(deleteDestination)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a Credential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "# The user_credential_name line is only needed if you come back later after your session has ended.\n",
+    "# user_credential_name = input(\"Enter a SAS Viya user name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteCredential = requests.delete(hostport + \"/credentials/domains/\" + domain_name + \"/users/\" + user_credential_name, headers = headersDelete)\n",
+    "print(deleteCredential)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Delete a Domain\n",
+    "\n",
+    "A domain can only be deleted if all credentials stored within the domain are deleted first.\n",
+    "\n",
+    "This can be done by including the following query parameter: includeCredentials=true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteDomain = requests.delete(hostport + \"/credentials/domains/\" + domain_name, headers = headersDelete)\n",
+    "print(deleteDomain)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete a Domain and all of the credentials stored within"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteDomain = requests.delete(hostport + \"/credentials/domains/\" + domain_name + \"?includeCredentials=true\", headers = headersDelete)\n",
+    "print(deleteDomain)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -407,7 +503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,

--- a/addons/destinations/CreateGitDestinationTechnicalUser.ipynb
+++ b/addons/destinations/CreateGitDestinationTechnicalUser.ipynb
@@ -50,6 +50,8 @@
     "import base64\n",
     "import urllib.parse\n",
     "\n",
+    "requests.packages.urllib3.disable_warnings()\n",
+    "\n",
     "hostport=\"https://viyatogo-singlenode\""
    ]
   },
@@ -137,7 +139,7 @@
     "\n",
     "# The domain name can be any easy to remember name. For example: gitdomain\n",
     "domain_name = input(\"Enter a domain name: \")\n",
-    "domain_description = input(\"Enter a domain description: \")\n",
+    "domain_description = input(\"Enter a domain description (optional): \")\n",
     "\n",
     "my_domain_url = hostport + domains_uri + domain_name\n",
     "domain_attrs = {\n",
@@ -172,8 +174,10 @@
     "domains = requests.get(hostport + domains_uri_limit, headers=headersGet)\n",
     "\n",
     "print(domains)\n",
+    "\n",
     "for i, domain in enumerate(domains.json()[\"items\"]):\n",
     "    print(\"%3d. domain name : %s \" % (i, domain[\"id\"]))\n",
+    "\n",
     "itemNotSelected = True\n",
     "while itemNotSelected : \n",
     "    domainIndex = input(\"Enter the index number to select a domain: \")\n",
@@ -182,6 +186,7 @@
     "        itemNotSelected = False\n",
     "    except:\n",
     "        print(\"Please enter the index number for a domain to select it from the list.\")\n",
+    "\n",
     "print(domain_name)"
    ]
   },
@@ -218,13 +223,13 @@
     "}\n",
     "\n",
     "# Group credential name is the Group ID on a SAS Viya system.\n",
-    "group_credential_name = input(\"Enter the group credential name: \")\n",
+    "group_credential_name = input(\"Enter the SAS Viya group name: \")\n",
     "group_credential_url = hostport + domains_uri + domain_name + \"/groups/\" + group_credential_name\n",
     "\n",
     "# User ID in Git\n",
     "gitUserId = input(\"Enter your Git user ID: \")\n",
     "\n",
-    "gitAccessToken = input(\"Enter the name of the Git access token: \")\n",
+    "gitAccessToken = input(\"Enter the value of the Git access token: \")\n",
     "\n",
     "encoded_userId = str(base64.b64encode(gitUserId.encode(\"utf-8\")), \"utf-8\")\n",
     "encoded_password = str(base64.b64encode(gitAccessToken.encode(\"utf-8\")), \"utf-8\")\n",
@@ -259,12 +264,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "credential_uri = \"/credentials/domains/\"+domain_name+\"/credentials\"\n",
+    "credential_uri = \"/credentials/domains/\" + domain_name + \"/credentials\"\n",
     "credentials = requests.get(hostport + credential_uri, headers=headersGet)\n",
     "\n",
     "print(credentials)\n",
     "for i, cred in enumerate(credentials.json()[\"items\"]):\n",
     "    print(\"%3d. credential name : %s \" % (i, cred[\"identityId\"]))\n",
+    "\n",
     "itemNotSelected = True\n",
     "while itemNotSelected : \n",
     "    credIndex = input(\"Enter the index number to select a credential: \")\n",
@@ -273,12 +279,15 @@
     "        itemNotSelected = False\n",
     "    except:\n",
     "        print(\"Please enter an index number to select a credential from the list.\")\n",
+    "\n",
     "print(cred_name)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Define a Git Destination\n",
     "\n",
@@ -288,17 +297,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "destName = input(\"Enter a destination name: \")\n",
-    "destDescription = input('Enter a description for the destination %s: ' % destName)\n",
+    "destDescription = input('Enter a description for the destination %s (optional): ' % destName)\n",
     "userEmail = input(\"Enter your user email address for Git: \")\n",
+    "\n",
+    "# This should be the HTTPS Clone URL of your Git Repository\n",
+    "# e.g. https://github.com/sassoftware/model-management-resources.git\n",
     "remoteRepositoryURL = input(\"Enter the URL for the Git Repository: \")\n",
     "gitBranch = input(\"Enter the Git branch: \")\n",
     "\n",
@@ -321,11 +328,11 @@
     "        \"value\": localRepositoryLocation},\n",
     "        {\"name\": \"userEmail\",\n",
     "        \"value\": userEmail},\n",
-    "        {\"name\": \"domainID\",\n",
+    "        {\"name\": \"credDomainId\",\n",
     "        \"value\": domain_name},\n",
     "        {\"name\": \"codeGenerationMode\",\n",
     "        \"value\": codeGenerationMode}]\n",
-    "}\n"
+    "}"
    ]
   },
   {
@@ -353,6 +360,7 @@
     "\n",
     "destination = requests.post(hostport + \"/modelPublish/destinations\", \n",
     "                       data=json.dumps(targetDestination), headers=headersPost, verify=False)\n",
+    "\n",
     "print(destination)\n",
     "pprint.pprint(destination.json())"
    ]
@@ -375,7 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "destination = requests.get(hostport + \"/modelPublish/destinations/\"+destName, headers=headersGet, verify=False)\n",
+    "destination = requests.get(hostport + \"/modelPublish/destinations/\"+ destName, headers=headersGet, verify=False)\n",
     "print(destination)\n",
     "pprint.pprint(destination.json())"
    ]
@@ -406,11 +414,86 @@
     "deleteDestination = requests.delete(hostport + \"/modelPublish/destinations/\" + destName, headers = headersDelete)\n",
     "print(deleteDestination)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a Credential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "# The group_credential_name line is only needed if you come back later after your session has ended.\n",
+    "# group_credential_name = input(\"Enter a SAS Viya group name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteCredential = requests.delete(hostport + \"/credentials/domains/\" + domain_name + \"/groups/\" + group_credential_name, headers = headersDelete)\n",
+    "print(deleteCredential)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a Domain\n",
+    "\n",
+    "A domain can only be deleted if all credentials stored within the domain are deleted first.\n",
+    "\n",
+    "This can be done by including the following query parameter: includeCredentials=true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteDomain = requests.delete(hostport + \"/credentials/domains/\" + domain_name, headers = headersDelete)\n",
+    "print(deleteDomain)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete a Domain and all of the credentials stored within"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The domain_name line is only needed if you come back later after your session has ended.\n",
+    "# domain_name = input(\"Enter a domain name: \")\n",
+    "\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteDomain = requests.delete(hostport + \"/credentials/domains/\" + domain_name + \"?includeCredentials=true\", headers = headersDelete)\n",
+    "print(deleteDomain)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.13 ('Airflow')",
    "language": "python",
    "name": "python3"
   },
@@ -424,7 +507,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "3fb4279e795a544b944f2de58d3d1d0e8eee0207c39e7dc1a9f9c96cf086e192"
+   }
   }
  },
  "nbformat": 4,

--- a/addons/destinations/CreateGitDestinationTechnicalUser.ipynb
+++ b/addons/destinations/CreateGitDestinationTechnicalUser.ipynb
@@ -1,0 +1,432 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Copyright © 2021, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Difference between this Notebook and the CreateGitDestination Notebook\n",
+    "\n",
+    "In the original [CreateGitDestination Notebook](./CreateGitDestination.ipynb) Git credentials are stored for each individual user.\n",
+    "\n",
+    "In this notebook the credentials will be stored with a user group instead. That means that the basic setup is exactly the same until Create ... Credential section. Here you will store credentials of a technical Git user with the user group. That means that the commits inside of the Git repository can not be connected to an individual user but rather only to a user group. As we encounter a lot use cases where the Git Publishing Destination is mainly used for CI/CD, using non individual credentials is a great reduction in administrative overhead when adding/removing people from a team."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Configure a Git Publishing Destination\n",
+    "\n",
+    "In order to create a Git destination, you must complete the following steps:\n",
+    "\n",
+    "1. Get an authorization token. \n",
+    "2. Create a domain or find a valid domain with Git credentials.\n",
+    "3. Create credentials for a specific user or group and define a credential domain.\n",
+    "4. Submit an API post to define and create a Git destination.\n",
+    "\n",
+    "   _**Note**: An example of an API request to delete a destination is also included._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json, os, pprint\n",
+    "import getpass\n",
+    "import base64\n",
+    "import urllib.parse\n",
+    "\n",
+    "hostport=\"https://viyatogo-singlenode\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get an Authorization Token and Define Headers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#Get Authorization Token\n",
+    "authUri=\"/SASLogon/oauth/token\"\n",
+    "\n",
+    "headersAuth={\n",
+    "    \"accept\":\"application/json\",\n",
+    "    \"content-type\":\"application/x-www-form-urlencoded\",\n",
+    "    \"Authorization\":\"Basic c2FzLmVjOg==\"\n",
+    "}\n",
+    "authToken=\"\"\n",
+    "user=\"\"\n",
+    "password=\"\"\n",
+    "notAuthed=True\n",
+    "\n",
+    "while notAuthed :\n",
+    "    user = input(\"Enter user ID: \")\n",
+    "    password =  urllib.parse.quote(getpass.getpass('Enter password for user %s:' % user))\n",
+    "    authBody='grant_type=password&username=' + user + '&password=' + password\n",
+    "    authReturn = requests.post(hostport+authUri, data=authBody, headers=headersAuth, verify=False)\n",
+    "    if authReturn.status_code == requests.codes.ok :\n",
+    "        authToken = authReturn.json()['access_token']\n",
+    "        notAuthed = False\n",
+    "    else :\n",
+    "        print(\"Please enter a valid user ID and password.\")\n",
+    "    \n",
+    "password = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "headersGet = {\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Domain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Domain\n",
+    "domains_uri = \"/credentials/domains/\"\n",
+    "credential_domain_headers = {\n",
+    "    \"If-Match\":\"false\",\n",
+    "    \"Content-Type\":\"application/json\",\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "\n",
+    "# The domain name can be any easy to remember name. For example: gitdomain\n",
+    "domain_name = input(\"Enter a domain name: \")\n",
+    "domain_description = input(\"Enter a domain description: \")\n",
+    "\n",
+    "my_domain_url = hostport + domains_uri + domain_name\n",
+    "domain_attrs = {\n",
+    "    \"id\":domain_name,\n",
+    "    \"type\":\"base64\",\n",
+    "    \"description\": domain_description\n",
+    "}\n",
+    "\n",
+    "domain = requests.put(my_domain_url, \n",
+    "                      data=json.dumps(domain_attrs), \n",
+    "                      headers=credential_domain_headers, verify=False)\n",
+    "\n",
+    "print(domain)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a List of Domains to Select a Domain From"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This code example enables a user to get a list of domains to select a domain from.\n",
+    "\n",
+    "domains_uri_limit = domains_uri + \"?limit=100\"\n",
+    "domains = requests.get(hostport + domains_uri_limit, headers=headersGet)\n",
+    "\n",
+    "print(domains)\n",
+    "for i, domain in enumerate(domains.json()[\"items\"]):\n",
+    "    print(\"%3d. domain name : %s \" % (i, domain[\"id\"]))\n",
+    "itemNotSelected = True\n",
+    "while itemNotSelected : \n",
+    "    domainIndex = input(\"Enter the index number to select a domain: \")\n",
+    "    try:\n",
+    "        domain_name = domains.json()[\"items\"][int(domainIndex)][\"id\"]\n",
+    "        itemNotSelected = False\n",
+    "    except:\n",
+    "        print(\"Please enter the index number for a domain to select it from the list.\")\n",
+    "print(domain_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Group Credential with a Git Access Token\n",
+    "\n",
+    "_**Note:** Gitlab is used in this example to show how to obtain a Git access token._\n",
+    "\n",
+    "1. Sign into your Gitlab account. \n",
+    "2. Click the user icon on the right side of the toolbar and select **Settings** from the drop-down menu.\n",
+    "3. In the left panel, click **Access Tokens**.\n",
+    "4. Enter a name for the Git token.\n",
+    "5. Specify a date for **Expires at**.\n",
+    "6. Select the **write_repository** option.\n",
+    "7. Click **Create personal access token**.\n",
+    "8. Copy or write down the token name. \n",
+    "   \n",
+    "   _**Important**: This token only shows once and cannot be retrieved later._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credential_group_headers = {\n",
+    "    \"If-Match\":\"false\",\n",
+    "    \"Content-Type\":\"application/json\",\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "\n",
+    "# Group credential name is the Group ID on a SAS Viya system.\n",
+    "group_credential_name = input(\"Enter the group credential name: \")\n",
+    "group_credential_url = hostport + domains_uri + domain_name + \"/groups/\" + group_credential_name\n",
+    "\n",
+    "# User ID in Git\n",
+    "gitUserId = input(\"Enter your Git user ID: \")\n",
+    "\n",
+    "gitAccessToken = input(\"Enter the name of the Git access token: \")\n",
+    "\n",
+    "encoded_userId = str(base64.b64encode(gitUserId.encode(\"utf-8\")), \"utf-8\")\n",
+    "encoded_password = str(base64.b64encode(gitAccessToken.encode(\"utf-8\")), \"utf-8\")\n",
+    "\n",
+    "credential_attrs = {\n",
+    "    \"domainId\":domain_name,\n",
+    "    \"identityType\":\"group\",\n",
+    "    \"identityId\":group_credential_name,\n",
+    "    \"domainType\":\"base64\",\n",
+    "    \"properties\":{\"gitUserId\":encoded_userId},\n",
+    "    \"secrets\":{\"gitAccessToken\":encoded_password}\n",
+    "}\n",
+    "\n",
+    "credential = requests.put(group_credential_url,\n",
+    "                          data=json.dumps(credential_attrs),\n",
+    "                          headers=credential_group_headers, verify=False)\n",
+    "\n",
+    "print(credential)\n",
+    "pprint.pprint(credential.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a Domain Credential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "credential_uri = \"/credentials/domains/\"+domain_name+\"/credentials\"\n",
+    "credentials = requests.get(hostport + credential_uri, headers=headersGet)\n",
+    "\n",
+    "print(credentials)\n",
+    "for i, cred in enumerate(credentials.json()[\"items\"]):\n",
+    "    print(\"%3d. credential name : %s \" % (i, cred[\"identityId\"]))\n",
+    "itemNotSelected = True\n",
+    "while itemNotSelected : \n",
+    "    credIndex = input(\"Enter the index number to select a credential: \")\n",
+    "    try:\n",
+    "        cred_name = credentials.json()[\"items\"][int(credIndex)][\"identityId\"]\n",
+    "        itemNotSelected = False\n",
+    "    except:\n",
+    "        print(\"Please enter an index number to select a credential from the list.\")\n",
+    "print(cred_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define a Git Destination\n",
+    "\n",
+    "_**Note:** After you create a domain and store the credential information for accessing your cloud provider, you can use this Jupyter notebook to define and create a publishing destination. You can also use SAS Environment Manager to define and create a Git publishing destination._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "destName = input(\"Enter a destination name: \")\n",
+    "destDescription = input('Enter a description for the destination %s: ' % destName)\n",
+    "userEmail = input(\"Enter your user email address for Git: \")\n",
+    "remoteRepositoryURL = input(\"Enter the URL for the Git Repository: \")\n",
+    "gitBranch = input(\"Enter the Git branch: \")\n",
+    "\n",
+    "# The codeGenerationMode property is currently only used when decisions or rule sets are published to a Git destination. \n",
+    "# The default value is \"MAS\", if a value is not specified.\n",
+    "codeGenerationMode = input(\"Enter a value of MAS or CAS for the code generation mode: \")\n",
+    "\n",
+    "localRepositoryLocation = \"/mmprojectpublic\"\n",
+    "\n",
+    "targetDestination={\n",
+    "    \"name\":destName,\n",
+    "    \"destinationType\":\"git\",\n",
+    "    \"description\":destDescription,\n",
+    "    \"properties\":[\n",
+    "        {\"name\": \"remoteRepositoryURL\",\n",
+    "        \"value\": remoteRepositoryURL},\n",
+    "        {\"name\": \"gitBranch\",\n",
+    "        \"value\": gitBranch},\n",
+    "        {\"name\": \"localRepositoryLocation\",\n",
+    "        \"value\": localRepositoryLocation},\n",
+    "        {\"name\": \"userEmail\",\n",
+    "        \"value\": userEmail},\n",
+    "        {\"name\": \"domainID\",\n",
+    "        \"value\": domain_name},\n",
+    "        {\"name\": \"codeGenerationMode\",\n",
+    "        \"value\": codeGenerationMode}]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a New Destination"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "headersPost = {\n",
+    "    \"Content-Type\":\"application/vnd.sas.models.publishing.destination.git+json\",\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "\n",
+    "destination = requests.post(hostport + \"/modelPublish/destinations\", \n",
+    "                       data=json.dumps(targetDestination), headers=headersPost, verify=False)\n",
+    "print(destination)\n",
+    "pprint.pprint(destination.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the New Destination"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "destination = requests.get(hostport + \"/modelPublish/destinations/\"+destName, headers=headersGet, verify=False)\n",
+    "print(destination)\n",
+    "pprint.pprint(destination.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete a Destination"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The destName line is only needed if you come back later after your session has ended.\n",
+    "# destName = input(\"Enter a destination name: \")\n",
+    "headersDelete={\n",
+    "    'Authorization': 'Bearer ' + authToken\n",
+    "}\n",
+    "deleteDestination = requests.delete(hostport + \"/modelPublish/destinations/\" + destName, headers = headersDelete)\n",
+    "print(deleteDestination)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/addons/destinations/README.md
+++ b/addons/destinations/README.md
@@ -1,6 +1,6 @@
 # Configuring Publishing Destinations
 
-This directory contains examples of Jupyter notebooks that you can use to create publishing destinations for CAS, Git, Azure Machine Learning, and container destinations such as Amazon Web Services (AWS), Azure, CAS, and Private Docker. 
+This directory contains examples of Jupyter notebooks that you can use to create publishing destinations for CAS, Git, Azure Machine Learning, and container destinations such as Amazon Web Services (AWS), Azure, CAS, and Private Docker.
 The [viya35](./viya35) directory contains the examples for configuration publishing destinations for SAS Model Manager 15.3 on SAS Viya 3.5 and SAS Open Model Manager 1.2.
 
 You can use the example Jupyter notebooks or Python scripts to create new publishing destinations for the following destination types: CAS, Amazon Web Services (AWS), Azure, Git, and Private Docker.
@@ -9,52 +9,53 @@ _**Note:** Creating publishing destinations for Azure and Git is supported only 
 
 ## SAS Viya 2020.1 and Later
 
-
 ### Prerequisites
 
 Here are the prerequisites for creating a new publishing destination for SAS Viya 2020.1 or later:
 
-* Make sure that you have Python 3 with the requests package installed on the machine where you are going to run the Jupyter notebooks or scripts.
-* Configure Azure to enable publishing validation for an Azure destination.
+- Make sure that you have Python 3 with the requests package installed on the machine where you are going to run the Jupyter notebooks or scripts.
+- Configure Azure to enable publishing validation for an Azure destination.
 
 For more information, see [Configuring Publishing Destinations](http://documentation.sas.com/?cdcId=mdlmgrcdc&cdcVersion=default&docsetId=mdlmgrag&docsetTarget=n0x0rvwqs9lvpun16sfdqoff4tsk.htm) in _SAS Model Manager: Administrator's Guide_.
-   
+
 ### Create Publishing Destinations
 
-* Make sure that you modify the host URL (host_name and port), SAS account, Domain name, or private Docker information in the examples before you run them.
+- Make sure that you modify the host URL (host_name and port), SAS account, Domain name, or private Docker information in the examples before you run them.
 
-* Run the Jupyter notebook or Python script for a specific destination type to create a publishing destination:
-  
-  * [CreateAMLDestination.ipynb](./CreateAMLDestination.ipynb)
-  * [CreateAWSDestination.ipynb](./CreateAWSDestination.ipynb)
-  * [CreateAzureDestination.ipynb](./CreateAzureDestination.ipynb)
-  * [CreateContainerDestinationWithGitRepo.ipynb](./CreateContainerDestinationWithGitRepo.ipynb)
-  * [CreateGCPDestination.ipynb](./CreateGCPDestination.ipynb)
-  * [CreateGitDestination.ipynb](./CreateGitDestination.ipynb)
-  * [CreatePrivateDockerDestination.ipynb](./CreatePrivateDockerDestination.ipynb)
-  * [create_cas_destination.py](./create_cas_destination.py)
+- Run the Jupyter notebook or Python script for a specific destination type to create a publishing destination:
 
+  - [CreateAMLDestination.ipynb](./CreateAMLDestination.ipynb)
+  - [CreateAWSDestination.ipynb](./CreateAWSDestination.ipynb)
+  - [CreateAzureDestination.ipynb](./CreateAzureDestination.ipynb)
+  - [CreateContainerDestinationWithGitRepo.ipynb](./CreateContainerDestinationWithGitRepo.ipynb)
+  - [CreateGCPDestination.ipynb](./CreateGCPDestination.ipynb)
+  - [CreateGitDestination.ipynb](./CreateGitDestination.ipynb)
+  - [CreateGitDestinationTechnicalUser.ipynb](./CreateGitDestinationTechnicalUser.ipynb)
+  - [CreatePrivateDockerDestination.ipynb](./CreatePrivateDockerDestination.ipynb)
+  - [create_cas_destination.py](./create_cas_destination.py)
 
 ## SAS Viya 3.5
 
 Here are the prerequisites for creating a new publishing destination for SAS Viya 3.5:
 
-* Make sure that you have Python 3 with the requests package installed on the machine where you are going to run the scripts.
+- Make sure that you have Python 3 with the requests package installed on the machine where you are going to run the scripts.
 
   Here is an example of using yum to install Python 3 on a machine:
+
   ```
    sudo yum install -y python3
    sudo pip3 install requests
-   ```
+  ```
 
-* If your destination type is AWS, you must create a credential domain in SAS Credentials service and store the AWS access key information in the credentials. Please modify the host URL (viya_host and port), SAS account, and AWS access key information in the script, and then enter the domain name in the create_aws_destination.py file.
+- If your destination type is AWS, you must create a credential domain in SAS Credentials service and store the AWS access key information in the credentials. Please modify the host URL (viya_host and port), SAS account, and AWS access key information in the script, and then enter the domain name in the create_aws_destination.py file.
+
   ```
    python create_aws_credential_domain.py
   ```
 
-* Make sure that you modify the host URL (viya_host and port), SAS account, Domain name, or private Docker information in the script before you run them.
+- Make sure that you modify the host URL (viya_host and port), SAS account, Domain name, or private Docker information in the script before you run them.
 
-* If Python 3 executable file name is 'python3', then update the following commands to use 'python3', instead of 'python'.
+- If Python 3 executable file name is 'python3', then update the following commands to use 'python3', instead of 'python'.
   ```
    python create_cas_destination.py
    python create_aws_destination.py


### PR DESCRIPTION
Fixed a bug in the CreateGitDestination.ipynb - when running the cell "Create a New Destination" the following error is thrown (found on 2022.1.1 and reproduced on 2022.1.4):
<Response [400]>
{'details': ['path: /modelPublish/destinations',
             'correlator: 216043ad-64cd-4e3d-9ef7-e4ff20a10175'],
 'errorCode': 21922,
 'httpStatusCode': 400,
 'message': 'A value for the Git destination property "domainID" was not '
            'specified.',
 'version': 2}
This is caused by the definition of the targetDestination in the previous step: {"name": "credDomainID", "value": domain_name} - should be: {"name": "domainID", "value": domain_name}

Added an Example Notebook to store the Git credentials with a user group instead of with a user. This is valuable for CI/CD use cases where Git isn't used as a change tracker but rather as the enabler for CI/CD.